### PR TITLE
Add gitleaks pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.0
+    hooks:
+      - id: gitleaks


### PR DESCRIPTION
## Summary
- Adds gitleaks pre-commit hook to catch secrets before they are committed
- Part of org-wide secret detection rollout (see [infra#20](https://gitlab.com/postgres-ai/infra/-/work_items/20), [infra#43](https://gitlab.com/postgres-ai/infra/-/work_items/43))

## Setup
After merging, developers should run:
```sh
pip install pre-commit  # if not already installed
pre-commit install
```